### PR TITLE
Add product options with pricing

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -3,14 +3,15 @@ import Slider from './ui/Slider';
 import Button from './ui/Button';
 import { useHouseStore } from '../store/houseStore';
 import { DoorOpen, Maximize2, Square } from 'lucide-react';
+import { windowOptions, doorOptions } from '../data/products';
 
 const ControlPanel: React.FC = () => {
   const {
     length, setLength,
     width, setWidth,
     height, setHeight,
-    hasWindow, toggleWindow,
-    hasDoor, toggleDoor
+    windowOption, selectWindow,
+    doorOption, selectDoor
   } = useHouseStore();
 
   const [activeTab, setActiveTab] = useState<'dimensions' | 'features'>('dimensions');
@@ -74,22 +75,47 @@ const ControlPanel: React.FC = () => {
         {activeTab === 'features' && (
           <div className="space-y-4">
             <h3 className="font-medium text-gray-700">Features</h3>
-            <div className="flex flex-col space-y-2">
-              {/* YOUR ORIGINAL BUTTON CODE HERE */}
-              <Button
-                onClick={toggleWindow}
-                active={hasWindow}
-                icon={<Square className="h-4 w-4" />}
-              >
-                {hasWindow ? 'Remove Window' : 'Add Window'}
-              </Button>
-              <Button
-                onClick={toggleDoor}
-                active={hasDoor}
-                icon={<DoorOpen className="h-4 w-4" />}
-              >
-                {hasDoor ? 'Remove Door' : 'Add Door'}
-              </Button>
+
+            <div className="space-y-4">
+              <div>
+                <h4 className="text-sm font-medium text-gray-600 mb-2">Windows</h4>
+                <div className="flex flex-col space-y-2">
+                  {windowOptions.map((option) => (
+                    <Button
+                      key={option.id}
+                      onClick={() =>
+                        selectWindow(
+                          windowOption?.id === option.id ? null : option
+                        )
+                      }
+                      active={windowOption?.id === option.id}
+                      icon={<Square className="h-4 w-4" />}
+                    >
+                      {option.name} (€{option.price})
+                    </Button>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <h4 className="text-sm font-medium text-gray-600 mb-2">Doors</h4>
+                <div className="flex flex-col space-y-2">
+                  {doorOptions.map((option) => (
+                    <Button
+                      key={option.id}
+                      onClick={() =>
+                        selectDoor(
+                          doorOption?.id === option.id ? null : option
+                        )
+                      }
+                      active={doorOption?.id === option.id}
+                      icon={<DoorOpen className="h-4 w-4" />}
+                    >
+                      {option.name} (€{option.price})
+                    </Button>
+                  ))}
+                </div>
+              </div>
             </div>
           </div>
         )}

--- a/src/components/HouseModel.tsx
+++ b/src/components/HouseModel.tsx
@@ -3,7 +3,9 @@ import { useHouseStore } from '../store/houseStore';
 import * as THREE from 'three';
 
 const HouseModel: React.FC = () => {
-  const { length, width, height, hasWindow, hasDoor } = useHouseStore();
+  const { length, width, height, windowOption, doorOption } = useHouseStore();
+  const hasWindow = !!windowOption;
+  const hasDoor = !!doorOption;
 
   // Calculate half dimensions for centering
   const halfLength = length / 2;

--- a/src/components/PriceDisplay.tsx
+++ b/src/components/PriceDisplay.tsx
@@ -3,14 +3,14 @@ import { useHouseStore } from '../store/houseStore';
 import { calculatePrice } from '../utils/calculations';
 
 const PriceDisplay: React.FC = () => {
-  const { length, width, hasWindow, hasDoor } = useHouseStore();
-  
+  const { length, width, windowOption, doorOption } = useHouseStore();
+
   const price = calculatePrice({
     floorArea: length * width,
-    windowCount: hasWindow ? 1 : 0,
-    doorCount: hasDoor ? 1 : 0
+    windowPrice: windowOption?.price ?? 0,
+    doorPrice: doorOption?.price ?? 0,
   });
-  
+
   return (
     <div className="bg-blue-50 rounded-lg p-4 border border-blue-100">
       <h3 className="text-lg font-medium text-gray-800 mb-1">Estimated Price</h3>
@@ -20,8 +20,8 @@ const PriceDisplay: React.FC = () => {
       </div>
       <div className="mt-2 text-xs text-gray-500">
         <p>Base: {length} × {width} m² @ €200/m²</p>
-        {hasWindow && <p>Window: +€250</p>}
-        {hasDoor && <p>Door: +€400</p>}
+        {windowOption && <p>{windowOption.name}: +€{windowOption.price}</p>}
+        {doorOption && <p>{doorOption.name}: +€{doorOption.price}</p>}
       </div>
     </div>
   );

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -1,0 +1,15 @@
+export interface FeatureOption {
+  id: string;
+  name: string;
+  price: number;
+}
+
+export const windowOptions: FeatureOption[] = [
+  { id: 'standard-window', name: 'Standard Window', price: 250 },
+  { id: 'double-glazed-window', name: 'Double-Glazed Window', price: 400 },
+];
+
+export const doorOptions: FeatureOption[] = [
+  { id: 'wooden-door', name: 'Wooden Door', price: 400 },
+  { id: 'glass-door', name: 'Glass Door', price: 550 },
+];

--- a/src/store/houseStore.ts
+++ b/src/store/houseStore.ts
@@ -1,16 +1,17 @@
 import { create } from 'zustand';
+import { FeatureOption } from '../data/products';
 
 interface HouseState {
   length: number;
   width: number;
   height: number;
-  hasWindow: boolean;
-  hasDoor: boolean;
+  windowOption: FeatureOption | null;
+  doorOption: FeatureOption | null;
   setLength: (length: number) => void;
   setWidth: (width: number) => void;
   setHeight: (height: number) => void;
-  toggleWindow: () => void;
-  toggleDoor: () => void;
+  selectWindow: (option: FeatureOption | null) => void;
+  selectDoor: (option: FeatureOption | null) => void;
 }
 
 export const useHouseStore = create<HouseState>((set) => ({
@@ -18,12 +19,12 @@ export const useHouseStore = create<HouseState>((set) => ({
   length: 8,
   width: 6,
   height: 3,
-  hasWindow: false,
-  hasDoor: false,
-  
+  windowOption: null,
+  doorOption: null,
+
   setLength: (length) => set({ length }),
   setWidth: (width) => set({ width }),
   setHeight: (height) => set({ height }),
-  toggleWindow: () => set((state) => ({ hasWindow: !state.hasWindow })),
-  toggleDoor: () => set((state) => ({ hasDoor: !state.hasDoor })),
+  selectWindow: (option) => set({ windowOption: option }),
+  selectDoor: (option) => set({ doorOption: option }),
 }));

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -1,14 +1,12 @@
 interface PriceParams {
   floorArea: number;
-  windowCount: number;
-  doorCount: number;
+  windowPrice: number;
+  doorPrice: number;
 }
 
-export const calculatePrice = ({ floorArea, windowCount, doorCount }: PriceParams): number => {
-  // Pricing formula: price = floor-area × €200 per m² + €250 per window + €400 per door
+export const calculatePrice = ({ floorArea, windowPrice, doorPrice }: PriceParams): number => {
+  // Pricing formula: price = floor-area × €200 per m² + selected window and door prices
   const basePrice = floorArea * 200;
-  const windowPrice = windowCount * 250;
-  const doorPrice = doorCount * 400;
-  
+
   return Math.round(basePrice + windowPrice + doorPrice);
 };


### PR DESCRIPTION
## Summary
- add data for window and door products with prices
- list product options in features tab and allow selecting them
- compute and display price based on selected products

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890fce948488327910bd5900c5a57cc