### PR TITLE
Move settings below 3D viewer and fill tabs with real options

### DIFF
--- a/src/components/HouseConfigurator.tsx
+++ b/src/components/HouseConfigurator.tsx
@@ -10,9 +10,9 @@ const HouseConfigurator: React.FC = () => {
   const { length, width, height } = useHouseConfigStore();
   
   return (
-    <div className="w-full max-w-7xl bg-white rounded-lg shadow-lg overflow-hidden flex flex-col lg:flex-row">
+    <div className="w-full max-w-7xl bg-white rounded-lg shadow-lg overflow-hidden flex flex-col">
       {/* 3D Viewer */}
-      <div className="w-full lg:w-2/3 h-[400px] lg:h-[600px] relative">
+      <div className="w-full h-[400px] md:h-[600px] relative">
         <Canvas
           camera={{ position: [10, 5, 10], fov: 50 }}
           shadows
@@ -45,10 +45,10 @@ const HouseConfigurator: React.FC = () => {
       </div>
       
       {/* Controls */}
-      <div className="w-full lg:w-1/3 p-6 flex flex-col">
+      <div className="w-full p-6 flex flex-col border-t border-gray-200">
         <h2 className="text-xl font-semibold text-gray-800 mb-6">House Configuration</h2>
         <TabsPanel />
-        <div className="mt-auto pt-6">
+        <div className="mt-6">
           <PriceSummary />
         </div>
       </div>

--- a/src/components/configurator/PriceSummary.tsx
+++ b/src/components/configurator/PriceSummary.tsx
@@ -1,17 +1,70 @@
 import React from 'react';
 import { useHouseConfigStore } from '../../store/houseConfigStore';
 import { windowOptions } from '../../data/windowOptions';
-import { roofOptions } from '../../data/roofOptions';
+import { roofCoverOptions } from '../../data/roofCoverOptions';
+import { doorOptions } from '../../data/doorOptions';
+import { gateOptions } from '../../data/gateOptions';
+import { foundationOptions } from '../../data/foundationOptions';
+import { facadeColorOptions } from '../../data/facadeOptions';
+import { undertakOptions } from '../../data/undertakOptions';
+import {
+  frameOptions,
+  insulationOptions,
+  installLayerOptions,
+  innerSurfaceOptions,
+} from '../../data/wallOptions';
 
 const PRICE_PER_SQM = 200;
 
 const PriceSummary: React.FC = () => {
-  const { length, width, selectedWindowId, selectedRoofId } = useHouseConfigStore();
+  const {
+    length,
+    width,
+    selectedWindowId,
+    selectedRoofCoverId,
+    selectedDoorId,
+    selectedGateId,
+    selectedFoundationId,
+    selectedFacadeColorId,
+    undertakId,
+    frameId,
+    insulationId,
+    installLayerId,
+    innerSurfaceId,
+    extensionPorch,
+    interiorDoor,
+  } = useHouseConfigStore();
 
   const base = length * width * PRICE_PER_SQM;
   const windowPrice = selectedWindowId ? windowOptions.find((w) => w.id === selectedWindowId)?.price ?? 0 : 0;
-  const roofPrice = roofOptions.find((r) => r.id === selectedRoofId)?.price ?? 0;
-  const extras = windowPrice + roofPrice;
+  const roofCoverPrice = roofCoverOptions.find((r) => r.id === selectedRoofCoverId)?.price ?? 0;
+  const doorPrice = selectedDoorId ? doorOptions.find((d) => d.id === selectedDoorId)?.price ?? 0 : 0;
+  const gatePrice = selectedGateId ? gateOptions.find((g) => g.id === selectedGateId)?.price ?? 0 : 0;
+  const foundationPrice = foundationOptions.find((f) => f.id === selectedFoundationId)?.price ?? 0;
+  const facadePrice = facadeColorOptions.find((f) => f.id === selectedFacadeColorId)?.price ?? 0;
+  const undertakPrice = undertakOptions.find((u) => u.id === undertakId)?.price ?? 0;
+  const framePrice = frameOptions.find((f) => f.id === frameId)?.price ?? 0;
+  const insulationPrice = insulationOptions.find((i) => i.id === insulationId)?.price ?? 0;
+  const installLayerPrice = installLayerOptions.find((i) => i.id === installLayerId)?.price ?? 0;
+  const innerSurfacePrice = innerSurfaceOptions.find((i) => i.id === innerSurfaceId)?.price ?? 0;
+  const extensionPrice = extensionPorch ? 18700 : 0;
+  const interiorDoorPrice = interiorDoor ? 1800 : 0;
+
+  const extras =
+    windowPrice +
+    roofCoverPrice +
+    doorPrice +
+    gatePrice +
+    foundationPrice +
+    facadePrice +
+    undertakPrice +
+    framePrice +
+    insulationPrice +
+    installLayerPrice +
+    innerSurfacePrice +
+    extensionPrice +
+    interiorDoorPrice;
+
   const total = base + extras;
 
   return (
@@ -22,12 +75,75 @@ const PriceSummary: React.FC = () => {
       </div>
       <div className="mt-2 text-xs text-gray-500 space-y-1">
         <p>Bas: {length} × {width} m² @ {PRICE_PER_SQM} kr/m² = {base.toLocaleString()} kr</p>
-        {roofPrice > 0 && (
-          <p>{roofOptions.find((r) => r.id === selectedRoofId)?.name}: +{roofPrice.toLocaleString()} kr</p>
+        {roofCoverPrice > 0 && (
+          <p>
+            {roofCoverOptions.find((r) => r.id === selectedRoofCoverId)?.name}: +
+            {roofCoverPrice.toLocaleString()} kr
+          </p>
+        )}
+        {undertakPrice > 0 && (
+          <p>
+            {undertakOptions.find((u) => u.id === undertakId)?.name}: +
+            {undertakPrice.toLocaleString()} kr
+          </p>
+        )}
+        {facadePrice > 0 && (
+          <p>
+            {facadeColorOptions.find((f) => f.id === selectedFacadeColorId)?.name}: +
+            {facadePrice.toLocaleString()} kr
+          </p>
         )}
         {windowPrice > 0 && (
-          <p>{windowOptions.find((w) => w.id === selectedWindowId)?.name}: +{windowPrice.toLocaleString()} kr</p>
+          <p>
+            {windowOptions.find((w) => w.id === selectedWindowId)?.name}: +
+            {windowPrice.toLocaleString()} kr
+          </p>
         )}
+        {doorPrice > 0 && (
+          <p>
+            {doorOptions.find((d) => d.id === selectedDoorId)?.name}: +
+            {doorPrice.toLocaleString()} kr
+          </p>
+        )}
+        {gatePrice > 0 && (
+          <p>
+            {(() => {
+              const g = gateOptions.find((g) => g.id === selectedGateId);
+              return g ? `${g.type} ${g.size}` : '';
+            })()}: +{gatePrice.toLocaleString()} kr
+          </p>
+        )}
+        {foundationPrice > 0 && (
+          <p>
+            {foundationOptions.find((f) => f.id === selectedFoundationId)?.name}: +
+            {foundationPrice.toLocaleString()} kr
+          </p>
+        )}
+        {framePrice > 0 && (
+          <p>
+            {frameOptions.find((f) => f.id === frameId)?.name}: +{framePrice.toLocaleString()} kr
+          </p>
+        )}
+        {insulationPrice > 0 && (
+          <p>
+            {insulationOptions.find((i) => i.id === insulationId)?.name}: +
+            {insulationPrice.toLocaleString()} kr
+          </p>
+        )}
+        {installLayerPrice > 0 && (
+          <p>
+            {installLayerOptions.find((i) => i.id === installLayerId)?.name}: +
+            {installLayerPrice.toLocaleString()} kr
+          </p>
+        )}
+        {innerSurfacePrice > 0 && (
+          <p>
+            {innerSurfaceOptions.find((i) => i.id === innerSurfaceId)?.name}: +
+            {innerSurfacePrice.toLocaleString()} kr
+          </p>
+        )}
+        {extensionPrice > 0 && <p>Farstukvist/veranda: +{extensionPrice.toLocaleString()} kr</p>}
+        {interiorDoorPrice > 0 && <p>Innerdörr 9x21: +{interiorDoorPrice.toLocaleString()} kr</p>}
         <p className="pt-1 font-medium text-gray-700">Totalt: {total.toLocaleString()} kr</p>
       </div>
     </div>

--- a/src/components/configurator/RoofSelector.tsx
+++ b/src/components/configurator/RoofSelector.tsx
@@ -17,7 +17,6 @@ const RoofSelector: React.FC = () => {
           <img src={opt.texture} alt={opt.name} className="w-full h-20 object-cover rounded" />
           <div className="mt-2 text-sm text-center">
             <p className="font-medium text-gray-700">{opt.name}</p>
-            <p className="text-gray-500 text-xs">+{opt.price.toLocaleString()} kr</p>
           </div>
         </button>
       ))}

--- a/src/components/configurator/TabsPanel.tsx
+++ b/src/components/configurator/TabsPanel.tsx
@@ -4,9 +4,58 @@ import RoofSelector from './RoofSelector';
 import WindowSelector from './WindowSelector';
 import Slider from '../ui/Slider';
 import { useHouseConfigStore } from '../../store/houseConfigStore';
+import { undertakOptions } from '../../data/undertakOptions';
+import { roofCoverOptions } from '../../data/roofCoverOptions';
+import { facadeColorOptions } from '../../data/facadeOptions';
+import { doorOptions } from '../../data/doorOptions';
+import { gateOptions } from '../../data/gateOptions';
+import { foundationOptions } from '../../data/foundationOptions';
+import {
+  frameOptions,
+  insulationOptions,
+  installLayerOptions,
+  innerSurfaceOptions,
+} from '../../data/wallOptions';
 
 const TabsPanel: React.FC = () => {
-  const { length, width, height, setLength, setWidth, setHeight } = useHouseConfigStore();
+  const {
+    length,
+    width,
+    height,
+    setLength,
+    setWidth,
+    setHeight,
+    carportSide,
+    setCarportSide,
+    roofConstruction,
+    setRoofConstruction,
+    undertakId,
+    setUndertak,
+    selectedRoofCoverId,
+    selectRoofCover,
+    extensionPorch,
+    toggleExtensionPorch,
+    selectedFacadeColorId,
+    setFacadeColor,
+    panelDirection,
+    setPanelDirection,
+    selectedDoorId,
+    selectDoor,
+    selectedGateId,
+    selectGate,
+    selectedFoundationId,
+    setFoundation,
+    frameId,
+    setFrame,
+    insulationId,
+    setInsulation,
+    installLayerId,
+    setInstallLayer,
+    innerSurfaceId,
+    setInnerSurface,
+    interiorDoor,
+    toggleInteriorDoor,
+  } = useHouseConfigStore();
 
   const tabs = [
     {
@@ -14,7 +63,7 @@ const TabsPanel: React.FC = () => {
       content: (
         <div className="space-y-4">
           <Slider
-            label="Length"
+            label="Längd (m)"
             value={length}
             onChange={(v) => setLength(v)}
             min={4}
@@ -22,7 +71,7 @@ const TabsPanel: React.FC = () => {
             step={0.1}
           />
           <Slider
-            label="Width"
+            label="Bredd (m)"
             value={width}
             onChange={(v) => setWidth(v)}
             min={4}
@@ -30,25 +79,291 @@ const TabsPanel: React.FC = () => {
             step={0.1}
           />
           <Slider
-            label="Height"
+            label="Vägghöjd (m)"
             value={height}
             onChange={(v) => setHeight(v)}
             min={2}
             max={5}
             step={0.1}
           />
+          <label className="block">
+            <span className="text-sm font-medium">Carport</span>
+            <select
+              value={carportSide}
+              onChange={(e) => setCarportSide(e.target.value as 'none' | 'short' | 'long')}
+              className="mt-1 block w-full border rounded-md p-2"
+            >
+              <option value="none">Ingen</option>
+              <option value="short">Kortsida</option>
+              <option value="long">Långsida</option>
+            </select>
+          </label>
         </div>
       ),
     },
-    { label: 'Taktyp', content: <RoofSelector /> },
-    { label: 'Yttertak', content: <div className="p-4 text-gray-500">Kommer snart</div> },
-    { label: 'Utbyggnader', content: <div className="p-4 text-gray-500">Kommer snart</div> },
-    { label: 'Fasad', content: <div className="p-4 text-gray-500">Kommer snart</div> },
+    {
+      label: 'Tak & undertak',
+      content: (
+        <div className="space-y-4">
+          <RoofSelector />
+          <label className="block">
+            <span className="text-sm font-medium">Konstruktion</span>
+            <select
+              value={roofConstruction}
+              onChange={(e) => setRoofConstruction(e.target.value)}
+              className="mt-1 block w-full border rounded-md p-2"
+            >
+              <option value="fackverk">Fackverk</option>
+              <option value="as-sparr">Ås/sparrtak</option>
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium">Undertak</span>
+            <select
+              value={undertakId}
+              onChange={(e) => setUndertak(e.target.value)}
+              className="mt-1 block w-full border rounded-md p-2"
+            >
+              {undertakOptions.map((u) => (
+                <option key={u.id} value={u.id}>
+                  {u.name} {u.price > 0 ? `(+${u.price.toLocaleString()} kr)` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      ),
+    },
+    {
+      label: 'Yttertak',
+      content: (
+        <div className="space-y-4">
+          <label className="block">
+            <span className="text-sm font-medium">Takbeklädnad</span>
+            <select
+              value={selectedRoofCoverId}
+              onChange={(e) => selectRoofCover(e.target.value)}
+              className="mt-1 block w-full border rounded-md p-2"
+            >
+              {roofCoverOptions.map((o) => (
+                <option key={o.id} value={o.id}>
+                  {o.name} {o.price > 0 ? `(+${o.price.toLocaleString()} kr)` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      ),
+    },
+    {
+      label: 'Utbyggnader',
+      content: (
+        <div className="space-y-2">
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              className="mr-2"
+              checked={extensionPorch}
+              onChange={toggleExtensionPorch}
+            />
+              Farstukvist/veranda (+18 700 kr)
+          </label>
+        </div>
+      ),
+    },
+    {
+      label: 'Fasad',
+      content: (
+        <div className="space-y-4">
+          <label className="block">
+            <span className="text-sm font-medium">Kulör</span>
+            <select
+              value={selectedFacadeColorId}
+              onChange={(e) => setFacadeColor(e.target.value)}
+              className="mt-1 block w-full border rounded-md p-2"
+            >
+              {facadeColorOptions.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name} {c.price > 0 ? `(+${c.price.toLocaleString()} kr)` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium">Panelriktning</span>
+              <select
+                value={panelDirection}
+                onChange={(e) =>
+                  setPanelDirection(e.target.value as 'stående' | 'liggande')
+                }
+                className="mt-1 block w-full border rounded-md p-2"
+              >
+              <option value="stående">Stående</option>
+              <option value="liggande">Liggande</option>
+            </select>
+          </label>
+        </div>
+      ),
+    },
     { label: 'Fönster', content: <WindowSelector /> },
-    { label: 'Dörrar', content: <div className="p-4 text-gray-500">Kommer snart</div> },
-    { label: 'Portar', content: <div className="p-4 text-gray-500">Kommer snart</div> },
-    { label: 'Grund', content: <div className="p-4 text-gray-500">Kommer snart</div> },
-    { label: 'Yttervägg', content: <div className="p-4 text-gray-500">Kommer snart</div> },
+    {
+      label: 'Ytterdörrar',
+      content: (
+        <div className="space-y-4">
+          <label className="block">
+            <span className="text-sm font-medium">Modell</span>
+            <select
+              value={selectedDoorId ?? ''}
+              onChange={(e) => selectDoor(e.target.value || null)}
+              className="mt-1 block w-full border rounded-md p-2"
+            >
+              <option value="">Ingen</option>
+              {doorOptions.map((d) => (
+                <option key={d.id} value={d.id}>
+                  {d.name} (+{d.price.toLocaleString()} kr)
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      ),
+    },
+    {
+      label: 'Portar',
+      content: (
+        <div className="space-y-4">
+          <label className="block">
+            <span className="text-sm font-medium">Typ & storlek</span>
+            <select
+              value={selectedGateId ?? ''}
+              onChange={(e) => selectGate(e.target.value || null)}
+              className="mt-1 block w-full border rounded-md p-2"
+            >
+              <option value="">Ingen</option>
+              {gateOptions.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.type} {g.size} (+{g.price.toLocaleString()} kr)
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      ),
+    },
+    {
+      label: 'Grund',
+      content: (
+        <div className="space-y-4">
+          <label className="block">
+            <span className="text-sm font-medium">Typ</span>
+            <select
+              value={selectedFoundationId}
+              onChange={(e) => setFoundation(e.target.value)}
+              className="mt-1 block w-full border rounded-md p-2"
+            >
+              {foundationOptions.map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.name} {f.price > 0 ? `(+${f.price.toLocaleString()} kr)` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      ),
+    },
+    {
+      label: 'Yttervägg',
+      content: (
+        <div className="space-y-4">
+          <label className="block">
+            <span className="text-sm font-medium">Stomme</span>
+            <select
+              value={frameId}
+              onChange={(e) => setFrame(e.target.value)}
+              className="mt-1 block w-full border rounded-md p-2"
+            >
+              {frameOptions.map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.name} {f.price > 0 ? `(+${f.price.toLocaleString()} kr)` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium">Isolering</span>
+            <select
+              value={insulationId}
+              onChange={(e) => setInsulation(e.target.value)}
+              className="mt-1 block w-full border rounded-md p-2"
+            >
+              {insulationOptions.map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.name} {f.price > 0 ? `(+${f.price.toLocaleString()} kr)` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium">Installationsskikt</span>
+            <select
+              value={installLayerId}
+              onChange={(e) => setInstallLayer(e.target.value)}
+              className="mt-1 block w-full border rounded-md p-2"
+            >
+              {installLayerOptions.map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.name} {f.price > 0 ? `(+${f.price.toLocaleString()} kr)` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium">Invändigt ytskikt</span>
+            <select
+              value={innerSurfaceId}
+              onChange={(e) => setInnerSurface(e.target.value)}
+              className="mt-1 block w-full border rounded-md p-2"
+            >
+              {innerSurfaceOptions.map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.name} {f.price > 0 ? `(+${f.price.toLocaleString()} kr)` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      ),
+    },
+    {
+      label: 'Interiör',
+      content: (
+        <div className="space-y-2">
+          <p className="text-sm text-gray-600">Innervägg: inget prispåslag</p>
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              className="mr-2"
+              checked={interiorDoor}
+              onChange={toggleInteriorDoor}
+            />
+              Innerdörr 9x21 (+1 800 kr)
+          </label>
+        </div>
+      ),
+    },
+    {
+      label: 'Export',
+      content: (
+        <div className="space-y-2">
+          <button className="px-3 py-1 border rounded">Spara ritning</button>
+          <button className="px-3 py-1 border rounded">Återuppta projekt</button>
+          <button className="px-3 py-1 border rounded">Ladda ner produktblad</button>
+          <button className="px-3 py-1 border rounded">Begär offert</button>
+          <button className="px-3 py-1 border rounded">Köp bygglovsritning</button>
+          <button className="px-3 py-1 border rounded">Chatt för bygglov</button>
+        </div>
+      ),
+    },
   ];
 
   return (

--- a/src/data/doorOptions.ts
+++ b/src/data/doorOptions.ts
@@ -1,0 +1,12 @@
+export interface DoorOption {
+  id: string;
+  name: string;
+  price: number;
+}
+
+export const doorOptions: DoorOption[] = [
+  { id: 'door-10x21-slat', name: '10x21 slät', price: 5700 },
+  { id: 'door-10x21-glas-sproj', name: '10x21 m. glas/spröjs', price: 7000 },
+  { id: 'door-10x21-stort-glas', name: '10x21 m. stort glas', price: 7000 },
+  { id: 'door-9x21-helglas', name: '9x21 helglas', price: 12100 },
+];

--- a/src/data/facadeOptions.ts
+++ b/src/data/facadeOptions.ts
@@ -1,0 +1,11 @@
+export interface FacadeColorOption {
+  id: string;
+  name: string;
+  price: number;
+}
+
+export const facadeColorOptions: FacadeColorOption[] = [
+  { id: 'facade-obehandlad', name: 'Obehandlad', price: 0 },
+  { id: 'facade-oljgrund', name: 'Oljgrund', price: 3400 },
+  { id: 'facade-falu', name: 'Falu röd', price: 3400 },
+];

--- a/src/data/foundationOptions.ts
+++ b/src/data/foundationOptions.ts
@@ -1,0 +1,12 @@
+export interface FoundationOption {
+  id: string;
+  name: string;
+  price: number;
+}
+
+export const foundationOptions: FoundationOption[] = [
+  { id: 'foundation-none', name: 'Ingen', price: 0 },
+  { id: 'foundation-betong300', name: 'Betong 300 mm', price: 19200 },
+  { id: 'foundation-betong400', name: 'Betong 400 mm', price: 21200 },
+  { id: 'foundation-bjalklag', name: 'Bjälklag i trä', price: 11000 },
+];

--- a/src/data/gateOptions.ts
+++ b/src/data/gateOptions.ts
@@ -1,0 +1,20 @@
+export interface GateOption {
+  id: string;
+  type: string;
+  size: string;
+  price: number;
+}
+
+export const gateOptions: GateOption[] = [
+  { id: 'slag-25x21', type: 'Slagport', size: '25x21', price: 14500 },
+  { id: 'slag-25x23', type: 'Slagport', size: '25x23', price: 18800 },
+  { id: 'tak-25x21', type: 'Takskjutport', size: '25x21', price: 12200 },
+  { id: 'tak-35x21', type: 'Takskjutport', size: '35x21', price: 25050 },
+  { id: 'tak-47x21', type: 'Takskjutport', size: '47x21', price: 30100 },
+  { id: 'vik-29x27', type: 'Vikport', size: '29x27', price: 24700 },
+  { id: 'vik-29x32', type: 'Vikport', size: '29x32', price: 27400 },
+  { id: 'vik-35x32', type: 'Vikport', size: '35x32', price: 28500 },
+  { id: 'vik-35x37', type: 'Vikport', size: '35x37', price: 29600 },
+  { id: 'vik-41x37', type: 'Vikport', size: '41x37', price: 32000 },
+  { id: 'vik-41x44', type: 'Vikport', size: '41x44', price: 33900 },
+];

--- a/src/data/roofCoverOptions.ts
+++ b/src/data/roofCoverOptions.ts
@@ -1,0 +1,13 @@
+export interface RoofCoverOption {
+  id: string;
+  name: string;
+  price: number;
+}
+
+export const roofCoverOptions: RoofCoverOption[] = [
+  { id: 'roof-none', name: 'Inget', price: 0 },
+  { id: 'roof-trp20', name: 'TRP-20 plåt', price: 16700 },
+  { id: 'roof-tegelprofil', name: 'Tegelprofilplåt', price: 17900 },
+  { id: 'roof-takpannor', name: 'Takpannor', price: 12700 },
+  { id: 'roof-klickfals', name: 'Klickfals', price: 20300 },
+];

--- a/src/data/roofOptions.ts
+++ b/src/data/roofOptions.ts
@@ -1,27 +1,23 @@
 export interface RoofOption {
   id: string;
   name: string;
-  price: number;
-  type: 'gable' | 'flat';
-  color: string; // hex color for material
   texture: string; // placeholder image path
 }
 
 export const roofOptions: RoofOption[] = [
   {
-    id: 'roof-gable',
-    name: 'Sadeltak',
-    price: 15000,
-    type: 'gable',
-    color: '#d97706',
+    id: 'roof-plant',
+    name: 'Plant innertak',
     texture: 'https://via.placeholder.com/80',
   },
   {
-    id: 'roof-flat',
-    name: 'Platt tak',
-    price: 8000,
-    type: 'flat',
-    color: '#6b7280',
+    id: 'roof-brutet',
+    name: 'Brutet innertak',
+    texture: 'https://via.placeholder.com/80',
+  },
+  {
+    id: 'roof-pulpett',
+    name: 'Pulpettak',
     texture: 'https://via.placeholder.com/80',
   },
 ];

--- a/src/data/undertakOptions.ts
+++ b/src/data/undertakOptions.ts
@@ -1,0 +1,10 @@
+export interface UndertakOption {
+  id: string;
+  name: string;
+  price: number;
+}
+
+export const undertakOptions: UndertakOption[] = [
+  { id: 'undertak-kondensduk', name: 'Kondensduk', price: 0 },
+  { id: 'undertak-råspont', name: 'Råspont & papp', price: 7400 },
+];

--- a/src/data/wallOptions.ts
+++ b/src/data/wallOptions.ts
@@ -1,0 +1,25 @@
+export interface SimpleOption {
+  id: string;
+  name: string;
+  price: number;
+}
+
+export const frameOptions: SimpleOption[] = [
+  { id: 'frame-145', name: 'Stomme 145 mm', price: 0 },
+  { id: 'frame-195', name: 'Stomme 195 mm', price: 1500 },
+];
+
+export const insulationOptions: SimpleOption[] = [
+  { id: 'insulation-none', name: 'Ingen isolering', price: 0 },
+  { id: 'insulation-package', name: 'Isoleringspaket', price: 18500 },
+];
+
+export const installLayerOptions: SimpleOption[] = [
+  { id: 'install-none', name: 'Inget installationsskikt', price: 0 },
+  { id: 'install-layer', name: 'Med installationsskikt', price: 3300 },
+];
+
+export const innerSurfaceOptions: SimpleOption[] = [
+  { id: 'inner-none', name: 'Inget invändigt ytskikt', price: 0 },
+  { id: 'inner-osb-gips', name: 'OSB & gips', price: 12600 },
+];

--- a/src/data/windowOptions.ts
+++ b/src/data/windowOptions.ts
@@ -8,6 +8,13 @@ export interface WindowOption {
 
 export const windowOptions: WindowOption[] = [
   {
+    id: 'window-9x5',
+    name: '9x5',
+    price: 3500,
+    size: [0.9, 0.5],
+    texture: 'https://via.placeholder.com/80',
+  },
+  {
     id: 'window-9x9',
     name: '9x9',
     price: 7300,
@@ -19,6 +26,41 @@ export const windowOptions: WindowOption[] = [
     name: '9x12',
     price: 8300,
     size: [0.9, 1.2],
+    texture: 'https://via.placeholder.com/80',
+  },
+  {
+    id: 'window-9x16',
+    name: '9x16',
+    price: 7800,
+    size: [0.9, 1.6],
+    texture: 'https://via.placeholder.com/80',
+  },
+  {
+    id: 'window-9x20',
+    name: '9x20',
+    price: 8200,
+    size: [0.9, 2.0],
+    texture: 'https://via.placeholder.com/80',
+  },
+  {
+    id: 'window-5x20',
+    name: '5x20',
+    price: 5100,
+    size: [0.5, 2.0],
+    texture: 'https://via.placeholder.com/80',
+  },
+  {
+    id: 'window-5x9',
+    name: '5x9',
+    price: 6400,
+    size: [0.5, 0.9],
+    texture: 'https://via.placeholder.com/80',
+  },
+  {
+    id: 'window-5x5',
+    name: '5x5',
+    price: 5400,
+    size: [0.5, 0.5],
     texture: 'https://via.placeholder.com/80',
   },
 ];

--- a/src/store/houseConfigStore.ts
+++ b/src/store/houseConfigStore.ts
@@ -1,28 +1,98 @@
 import { create } from 'zustand';
 import { roofOptions } from '../data/roofOptions';
+import { roofCoverOptions } from '../data/roofCoverOptions';
+import { foundationOptions } from '../data/foundationOptions';
+import { facadeColorOptions } from '../data/facadeOptions';
+import {
+  frameOptions,
+  insulationOptions,
+  installLayerOptions,
+  innerSurfaceOptions,
+} from '../data/wallOptions';
+import { undertakOptions } from '../data/undertakOptions';
 
 interface HouseConfigState {
   length: number;
   width: number;
   height: number;
-  selectedWindowId: string | null;
+  carportSide: 'none' | 'short' | 'long';
+  roofConstruction: string;
+  undertakId: string;
   selectedRoofId: string;
+  selectedRoofCoverId: string;
+  extensionPorch: boolean;
+  selectedFacadeColorId: string;
+  panelDirection: 'stående' | 'liggande';
+  selectedWindowId: string | null;
+  selectedDoorId: string | null;
+  selectedGateId: string | null;
+  selectedFoundationId: string;
+  frameId: string;
+  insulationId: string;
+  installLayerId: string;
+  innerSurfaceId: string;
+  interiorDoor: boolean;
   setLength: (val: number) => void;
   setWidth: (val: number) => void;
   setHeight: (val: number) => void;
-  selectWindow: (id: string | null) => void;
+  setCarportSide: (v: 'none' | 'short' | 'long') => void;
+  setRoofConstruction: (v: string) => void;
+  setUndertak: (id: string) => void;
   selectRoof: (id: string) => void;
+  selectRoofCover: (id: string) => void;
+  toggleExtensionPorch: () => void;
+  setFacadeColor: (id: string) => void;
+  setPanelDirection: (v: 'stående' | 'liggande') => void;
+  selectWindow: (id: string | null) => void;
+  selectDoor: (id: string | null) => void;
+  selectGate: (id: string | null) => void;
+  setFoundation: (id: string) => void;
+  setFrame: (id: string) => void;
+  setInsulation: (id: string) => void;
+  setInstallLayer: (id: string) => void;
+  setInnerSurface: (id: string) => void;
+  toggleInteriorDoor: () => void;
 }
 
 export const useHouseConfigStore = create<HouseConfigState>((set) => ({
   length: 8,
   width: 6,
   height: 3,
-  selectedWindowId: null,
+  carportSide: 'none',
+  roofConstruction: 'fackverk',
+  undertakId: undertakOptions[0].id,
   selectedRoofId: roofOptions[0].id,
+  selectedRoofCoverId: roofCoverOptions[0].id,
+  extensionPorch: false,
+  selectedFacadeColorId: facadeColorOptions[0].id,
+  panelDirection: 'stående',
+  selectedWindowId: null,
+  selectedDoorId: null,
+  selectedGateId: null,
+  selectedFoundationId: foundationOptions[0].id,
+  frameId: frameOptions[0].id,
+  insulationId: insulationOptions[0].id,
+  installLayerId: installLayerOptions[0].id,
+  innerSurfaceId: innerSurfaceOptions[0].id,
+  interiorDoor: false,
   setLength: (length) => set({ length }),
   setWidth: (width) => set({ width }),
   setHeight: (height) => set({ height }),
+  setCarportSide: (carportSide) => set({ carportSide }),
+  setRoofConstruction: (roofConstruction) => set({ roofConstruction }),
+  setUndertak: (undertakId) => set({ undertakId }),
+  selectRoof: (selectedRoofId) => set({ selectedRoofId }),
+  selectRoofCover: (selectedRoofCoverId) => set({ selectedRoofCoverId }),
+  toggleExtensionPorch: () => set((s) => ({ extensionPorch: !s.extensionPorch })),
+  setFacadeColor: (selectedFacadeColorId) => set({ selectedFacadeColorId }),
+  setPanelDirection: (panelDirection) => set({ panelDirection }),
   selectWindow: (id) => set({ selectedWindowId: id }),
-  selectRoof: (id) => set({ selectedRoofId: id }),
+  selectDoor: (id) => set({ selectedDoorId: id }),
+  selectGate: (id) => set({ selectedGateId: id }),
+  setFoundation: (selectedFoundationId) => set({ selectedFoundationId }),
+  setFrame: (frameId) => set({ frameId }),
+  setInsulation: (insulationId) => set({ insulationId }),
+  setInstallLayer: (installLayerId) => set({ installLayerId }),
+  setInnerSurface: (innerSurfaceId) => set({ innerSurfaceId }),
+  toggleInteriorDoor: () => set((s) => ({ interiorDoor: !s.interiorDoor })),
 }));


### PR DESCRIPTION
## Summary
- stack configurator UI below the 3D house view
- replace placeholder panels with interactive options for roofs, facade, openings, foundation and more

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68910cceb534832795712e9f0dba1ef4