### PR TITLE
Add shadow bias to directional light to reduce shadow acne

### DIFF
--- a/src/components/HouseConfigurator.tsx
+++ b/src/components/HouseConfigurator.tsx
@@ -19,12 +19,13 @@ const HouseConfigurator: React.FC = () => {
           className="w-full h-full"
         >
           <ambientLight intensity={0.3} />
-          <directionalLight 
-            position={[10, 10, 5]} 
-            intensity={1} 
-            castShadow 
+          <directionalLight
+            position={[10, 10, 5]}
+            intensity={1}
+            castShadow
             shadow-mapSize-width={1024}
             shadow-mapSize-height={1024}
+            shadow-bias={-0.0005}
           />
           <HouseModel />
           <OrbitControls 


### PR DESCRIPTION
## Summary
- reduce shadow acne by adding shadow bias to directional light in HouseConfigurator

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bb93cb550832787f0162553cfdcb2